### PR TITLE
Adding single instance and command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ it works like this:
 
 ![dimmer screenshot](https://raw.githubusercontent.com/clangen/clangen-projects-static/master/dimmer/screenshots/screenshot.png)
 
+# command line
+
+dimmer now supports reading the name of a config file from the command line.  The file must reside in 
+%APPDATA%\dimmer
+
+for example:
+
+```
+dimmer dark
+```
+
+will read the config file dark.json
+
 # installation
 
 download, unzip, and run! no installation or additional runtimes required.

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -63,6 +63,10 @@ static std::wstring getConfigFilename() {
     return getDataDirectory() + L"\\config.json";
 }
 
+static std::wstring getConfigFilename(std::wstring configName) {
+    return getDataDirectory() + L"\\" + configName + L".json";
+}
+
 static BOOL CALLBACK MonitorEnumProc(HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data) {
     auto monitors = reinterpret_cast<std::vector<Monitor>*>(data);
     int index = (int) monitors->size();
@@ -138,8 +142,7 @@ namespace dimmer {
         saveConfig();
     }
 
-    void loadConfig() {
-        std::string config = fileToString(getConfigFilename());
+    void parseConfig(std::string config) {
         try {
             json j = json::parse(config);
             auto m = j.find("monitors");
@@ -163,6 +166,22 @@ namespace dimmer {
         }
         catch (...) {
             /* move on... */
+        }
+    }
+
+    void loadConfig() {
+        std::string config = fileToString(getConfigFilename());
+        parseConfig(config);
+    }
+    
+    // Support loading a config from a file path
+    void loadConfig(LPWSTR configName) {
+        try {
+            std::string config = fileToString(getConfigFilename(configName));
+            parseConfig(config);
+        }
+        catch (...) {
+            // nothing
         }
     }
 

--- a/src/Monitor.h
+++ b/src/Monitor.h
@@ -58,6 +58,10 @@ namespace dimmer {
             if (pos == 0) {
                 name = name.substr(4);
             }
+            
+            // Include the monitor size in the name
+            name = name + L" " + std::to_wstring(this->info.rcMonitor.right - this->info.rcMonitor.left) + L"x" + std::to_wstring(this->info.rcMonitor.bottom - this->info.rcMonitor.top);
+
             return name;
         }
 

--- a/src/Monitor.h
+++ b/src/Monitor.h
@@ -78,5 +78,6 @@ namespace dimmer {
     extern bool isDimmerEnabled();
     extern void setDimmerEnabled(bool enabled);
     extern void loadConfig();
+    extern void loadConfig(LPWSTR configName);
     extern void saveConfig();
 }

--- a/src/dimmer.vcxproj
+++ b/src/dimmer.vcxproj
@@ -14,19 +14,19 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9867E299-7151-4EE9-9A0F-499F9B515060}</ProjectGuid>
     <RootNamespace>dimmer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,20 @@ using Overlays = std::map<std::wstring, OverlayPtr>;
 static Overlays overlays;
 static std::vector<dimmer::Monitor> monitors;
 
+// Interprocess messaging
+#define BUF_SIZE 256
+TCHAR szName[] = TEXT("DimmerFileMapping");
+HANDLE hMapFile;
+LPCTSTR pBuf;
+
+// The second one is used so the remote process can talk back to us.
+TCHAR szName2[] = TEXT("DimmerFileTalkback");
+HANDLE hMapFile2;
+LPWSTR pBuf2;
+
+// This custom window message tells the first instance to reload its config file.
+const UINT WM_CUSTOM_ARGS = WM_USER + 90;
+
 static void updateOverlays(HINSTANCE instance) {
     monitors = dimmer::queryMonitors();
 
@@ -76,14 +90,195 @@ static void updateOverlays(HINSTANCE instance) {
     }
 }
 
+// Check to see if this is the first instance by seeing if the file map exists.
+static DWORD isFirstInstance() {
+
+    HANDLE hMapFile;
+    LPCTSTR pBuf;
+
+    hMapFile = OpenFileMapping(
+        FILE_MAP_ALL_ACCESS,   // read/write access
+        FALSE,                 // do not inherit the name
+        szName);               // name of mapping object
+
+    if (hMapFile == NULL)
+    {
+        // Must be the first instance
+        return 0;
+    }
+
+    pBuf = (LPTSTR)MapViewOfFile(hMapFile, // handle to map object
+        FILE_MAP_ALL_ACCESS,  // read/write permission
+        0,
+        0,
+        BUF_SIZE);
+
+    if (pBuf == NULL)
+    {
+        CloseHandle(hMapFile);
+        // Still the first instance
+        return 0;
+    }
+
+    // Convert the string to a thread ID.
+    DWORD otherThreadID = _wtoi(pBuf);
+    UnmapViewOfFile(pBuf);
+    CloseHandle(hMapFile);
+    return otherThreadID;
+}
+
+// OK, we must be the first instance -- create our two memory mapped files.
+static bool makeFirstInstance() {
+
+    hMapFile = CreateFileMapping(
+        INVALID_HANDLE_VALUE,    // use paging file
+        NULL,                    // default security
+        PAGE_READWRITE,          // read/write access
+        0,                       // maximum object size (high-order DWORD)
+        BUF_SIZE,                // maximum object size (low-order DWORD)
+        szName);                 // name of mapping object
+
+    if (hMapFile == NULL)
+    {
+        //_tprintf(TEXT("Could not create file mapping object (%d).\n"), GetLastError());
+        char buffer[100];
+        sprintf(buffer, "Could not create file mapping object (%d).\n", GetLastError());
+        wchar_t wtext[100];
+        mbstowcs(wtext, buffer, strlen(buffer) + 1);//Plus null
+        MessageBox(NULL, wtext, TEXT("SETUP"), MB_OK);
+        return false;
+    }
+    pBuf = (LPTSTR)MapViewOfFile(hMapFile,   // handle to map object
+        FILE_MAP_ALL_ACCESS, // read/write permission
+        0,
+        0,
+        BUF_SIZE);
+
+    if (pBuf == NULL)
+    {
+        //_tprintf(TEXT("Could not map view of file (%d).\n"),
+        //    GetLastError());
+
+        MessageBox(NULL, TEXT("Could not map view"), TEXT("SETUP"), MB_OK);
+
+        CloseHandle(hMapFile);
+        return false;
+    }
+
+    // Write my thread ID into the buffer.
+    char buffer[100];
+    sprintf(buffer, "%d.\n", GetCurrentThreadId());
+    wchar_t wtext[100];
+    mbstowcs(wtext, buffer, strlen(buffer) + 1);//Plus null
+    CopyMemory((PVOID)pBuf, wtext, (strlen(buffer) * sizeof(wchar_t)));
+
+    // Create the second one
+    hMapFile2 = CreateFileMapping(
+        INVALID_HANDLE_VALUE,    // use paging file
+        NULL,                    // default security
+        PAGE_READWRITE,          // read/write access
+        0,                       // maximum object size (high-order DWORD)
+        BUF_SIZE,                // maximum object size (low-order DWORD)
+        szName2);                 // name of mapping object
+
+    if (hMapFile2 == NULL)
+    {
+        return false;
+    }
+    pBuf2 = (LPTSTR)MapViewOfFile(hMapFile2,   // handle to map object
+        FILE_MAP_ALL_ACCESS, // read/write permission
+        0,
+        0,
+        BUF_SIZE);
+
+    if (pBuf2 == NULL)
+    {
+        CloseHandle(hMapFile2);
+        return false;
+    }
+}
+
+// Close up the handles on exit.
+static void CloseMap() {
+    UnmapViewOfFile(pBuf);
+    CloseHandle(hMapFile);
+    UnmapViewOfFile(pBuf2);
+    CloseHandle(hMapFile2);
+}
+
+// Write the received arguments into the second memory map, for the first instance to consume.
+static bool writeArgsBack(LPWSTR args) {
+
+    HANDLE hMapFile;
+    LPCTSTR pBuf;
+
+    hMapFile = OpenFileMapping(
+        FILE_MAP_ALL_ACCESS,   // read/write access
+        FALSE,                 // do not inherit the name
+        szName2);               // name of mapping object
+
+    if (hMapFile == NULL)
+    {
+        // Something went wrong
+        return false;
+    }
+
+    pBuf = (LPTSTR)MapViewOfFile(hMapFile, // handle to map object
+        FILE_MAP_ALL_ACCESS,  // read/write permission
+        0,
+        0,
+        BUF_SIZE);
+
+    if (pBuf == NULL)
+    {
+        CloseHandle(hMapFile);
+        return false;
+    }
+
+    // Write the args into it!
+    CopyMemory((PVOID)pBuf, args, wcslen(args) * sizeof(LPWSTR));
+}
+
+// Parse the incoming application arguments.
+void parseArgs(LPWSTR args, HINSTANCE instance) {
+    // For now, only a single argument is supported: The name of an alternate config file
+    // This config file is loaded and the current config is replaced.
+    dimmer::loadConfig(args);
+
+    // Update the screen after the config change.
+    updateOverlays(instance);
+}
+
+// MAIN function
 int CALLBACK wWinMain(HINSTANCE instance, HINSTANCE prev, LPWSTR args, int showType) {
     InitCommonControlsEx(nullptr);
 
+    // See if the app is already running.  If so, exit.
+    DWORD otherThread = isFirstInstance();
+    if (otherThread > 0) {
+        // Write something into the mapping so the first guy picks it up
+        if (wcslen(args) > 0) { // Make sure there is actually something to write back
+            writeArgsBack(args);
+            // Send a message to the other thread.
+            PostThreadMessage(otherThread, WM_CUSTOM_ARGS, (WPARAM)0, (LPARAM)0);
+        }
+        return 0;
+    }
+
+    // Set up the file map.
+    makeFirstInstance();
+
+    // Load existing config.json off of disk.
     dimmer::loadConfig();
 
     dimmer::TrayMenu trayMenu(instance, [instance]() {
         updateOverlays(instance);
     });
+
+    // Parse command-line arguments
+    if (wcslen(args) > 0) { // ONly if some were passed.
+        parseArgs(args, instance);
+    }
 
     trayMenu.setPopupMenuChangedCallback([](bool visible) {
         for (auto overlay : overlays) {
@@ -98,8 +293,17 @@ int CALLBACK wWinMain(HINSTANCE instance, HINSTANCE prev, LPWSTR args, int showT
 
     MSG msg = {};
     while (GetMessage(&msg, nullptr, 0, 0)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        switch (msg.message)
+        {
+            case WM_CUSTOM_ARGS:
+                // We've received instructions from the other instance of the app.
+                parseArgs(pBuf2, instance);
+
+                break;
+            default:
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+        }
     }
 
     dimmer::saveConfig();
@@ -107,6 +311,7 @@ int CALLBACK wWinMain(HINSTANCE instance, HINSTANCE prev, LPWSTR args, int showT
     monitors.clear();
     overlays.clear();
 
+    CloseMap();
+
     return 0;
 }
-


### PR DESCRIPTION
This change adds three features to the application:
- Single instance: If you try to run dimmer.exe and it is already running, nothing will happen
- Monitor resolution is displayed in right-click menu
- Command line arguments.  Currently the only argument supported is the name of the config file to load.  Additional config files must reside in the %APPDATA%\dimmer directory, where the main config.json sits.  

Example:
```
dimmer.exe dark
```
will load and immediately apply dark.json from %APPDATA%\dimmer

This goes hand-in-hand with the "single instance" -- if the app is already running, the instructions are passed to the running instance and the display is immediately updated.

Note that I am not an expert at C++, please feel free to adjust my code where necessary.